### PR TITLE
Binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The data in NetCDF and CSV formats can be downloaded from the [Zenodo repository
 In the folder `notebooks` there are two Jupyter notebooks which shows how to deal effectively with the NetCDF data in `xarray` and how to visualise them in several ways by using matplotlib or the [enlopy](https://github.com/kavvkon/enlopy) package. 
 
 There are currently two notebooks: 
-  - `exploring-ERA-NUTS`: it shows how to open the NetCDF files (with Dask), how to manipulate and visualise them. 
-  - `ERA-NUTS-explore-with-widget`: explore interactively the datasets with [jupyter](https://jupyter.org/) and [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/). (You need download the notebook locally)
+  - `exploring-ERA-NUTS`: it shows how to open the NetCDF files (with Dask), how to manipulate and visualise them. A rendered version is also available as html
+  - `ERA-NUTS-explore-with-widget`: explore interactively the datasets with [jupyter](https://jupyter.org/) and [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/). (You need to download the notebook locally)
 
-The notebook `exploring-ERA-NUTS` is also available rendered as HTML. 
-
-# Additional files
+Both notebooks can be edited and run online (including widgets) by clicking here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/energy-modelling-toolkit/era-nuts-code/master?filepath=notebooks).
+ 
+ # Additional files
 
 In the folder `additional files` there is a map showing the spatial resolution of the ERA5 reanalysis and a CSV file specifying the number of grid points with respect to each NUTS0/1/2 region.
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - netcdf4
   - xarray
   - ipywidgets
+  - dask
   - rise
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - matplotlib>=2.0
   - pandas>=0.22
   - scipy>=1.0
+  - statsmodels
   - enlopy
   - netcdf4
   - xarray

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,16 @@
+name: era5-nuts-binder
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - numpy>=1.12
+  - matplotlib>=2.0
+  - pandas>=0.22
+  - scipy>=1.0
+  - enlopy
+  - netcdf4
+  - xarray
+  - ipywidgets
+  - rise
+

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+wget -q -O era-nuts-t2m-nuts2-hourly.nc  https://zenodo.org/record/2650191/files/era-nuts-t2m-nuts2-hourly.nc?download=1
+wget -q -O era-nuts-ws10-nuts2-hourly.nc https://zenodo.org/record/2650191/files/era-nuts-ws10-nuts2-hourly.nc?download=1

--- a/notebooks/ERA-NUTS-explore-with-widget.ipynb
+++ b/notebooks/ERA-NUTS-explore-with-widget.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "path = r'/emhires-data/data-warehouse/tabular/ERA-NUTS/'\n",
+    "path = r'..'\n",
     "# path = '.'"
    ]
   },
@@ -89,7 +89,7 @@
     }
    ],
    "source": [
-    "ds = xr.open_mfdataset(path + 'NUTS2/hourly/*.nc', mask_and_scale=True)\n",
+    "ds = xr.open_mfdataset(path + '/*.nc', mask_and_scale=True)\n",
     "ds"
    ]
   },
@@ -253,7 +253,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.1"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/ERA-NUTS-explore-with-widget.ipynb
+++ b/notebooks/ERA-NUTS-explore-with-widget.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-04-17T09:22:02.106975Z",
@@ -20,7 +20,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-04-17T09:22:02.862422Z",
+     "start_time": "2019-04-17T09:22:02.860349Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import interact, IntRangeSlider, ToggleButtons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-04-17T09:22:02.127945Z",
@@ -58,36 +72,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-04-17T09:22:02.350255Z",
      "start_time": "2019-04-17T09:22:02.129529Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<xarray.Dataset>\n",
-       "Dimensions:  (region: 309, time: 341880)\n",
-       "Coordinates:\n",
-       "  * time     (time) datetime64[ns] 1980-01-01 ... 2018-12-31T23:00:00\n",
-       "  * region   (region) object 'AL01' 'AL02' 'AL03' ... 'UKM8' 'UKM9' 'UKN0'\n",
-       "Data variables:\n",
-       "    CS       (time, region) float32 dask.array<shape=(341880, 309), chunksize=(341880, 309)>\n",
-       "    ssrd     (time, region) float32 dask.array<shape=(341880, 309), chunksize=(341880, 309)>\n",
-       "    ssrdc    (time, region) float32 dask.array<shape=(341880, 309), chunksize=(341880, 309)>\n",
-       "    t2m      (time, region) float32 dask.array<shape=(341880, 309), chunksize=(341880, 309)>\n",
-       "    ws10     (time, region) float32 dask.array<shape=(341880, 309), chunksize=(341880, 309)>\n",
-       "    ws100    (time, region) float32 dask.array<shape=(341880, 309), chunksize=(341880, 309)>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ds = xr.open_mfdataset(path + '/*.nc', mask_and_scale=True)\n",
     "ds"
@@ -109,86 +101,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-04-17T09:22:02.862422Z",
-     "start_time": "2019-04-17T09:22:02.860349Z"
+     "end_time": "2019-04-17T09:22:03.221021Z",
+     "start_time": "2019-04-17T09:22:02.863892Z"
     }
    },
    "outputs": [],
    "source": [
-    "from ipywidgets import interact"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-04-17T09:22:03.221021Z",
-     "start_time": "2019-04-17T09:22:02.863892Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a651dda524f24e8d8e6dae82fbe0cb29",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(Dropdown(description='var', options=('t2m', 'ssrd', 'ssrdc', 'ws10', 'ws100', 'CS'), val…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "@interact(var=['t2m','ssrd','ssrdc','ws10','ws100','CS'], \n",
+    "@interact(var=list(ds.data_vars), \n",
     "          region=ds.coords['region'].values,\n",
     "          month=(1,12),\n",
     "          year=(1980,2018))\n",
     "def plot_region_month(var, region, year, month):\n",
-    "    ds_hourly[var].sel(time='{}-{}'.format(year, month), region=region).plot(color='k') # year"
+    "    ds[var].sel(time='{}-{}'.format(year, month), region=region).plot(color='k') # year"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-04-17T09:22:03.221021Z",
      "start_time": "2019-04-17T09:22:02.863892Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72b4df73aff3457f8d58f115276ee60a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(Dropdown(description='var', options=('t2m', 'ssrd', 'ssrdc', 'ws10', 'ws100', 'CS'), val…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "@interact(var=['t2m','ssrd','ws10','ws100','CS'], \n",
+    "@interact(var=list(ds.data_vars), \n",
     "          region=ds.coords['region'].values,\n",
-    "          from_year=(1980,2018),\n",
-    "          to_year=(1980,2018)\n",
-    "          )\n",
-    "def plot_region_month(var, region, from_year, to_year):\n",
-    "    data_sel = ds[var].sel(region = region)\n",
-    "    data_sel.sel(time=slice('{}'.format(from_year), '{}'.format(to_year))).resample(time = 'M').mean().plot(color='k') # year"
+    "          year_range=IntRangeSlider(min=1980,max=2018),\n",
+    "          timestep=ToggleButtons(options=[('week','w'),('month','m'),('year','a')]),\n",
+    "          continuous_update=False,\n",
+    "         )\n",
+    "def plot_region_month(var, region, year_range,timestep='m'):\n",
+    "    (ds[var].sel(region=region,\n",
+    "                 time=slice(str(year_range[0]), str(year_range[1])))\n",
+    "            .resample(time=timestep).mean()\n",
+    "            .plot(color='k')\n",
+    "    )"
    ]
   },
   {
@@ -200,34 +152,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-04-17T09:22:05.540679Z",
      "start_time": "2019-04-17T09:22:03.222583Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5c04e94516044ba1a717b97320b499d3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(Dropdown(description='var', options=('t2m', 'ssrd', 'ssrdc', 'ws10', 'ws100', 'CS'), val…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Extract unique countries by taking the first two characters of all regions\n",
     "countries = set(s[0:2] for s in ds.coords['region'].values)\n",
     "\n",
-    "@interact(var=['t2m','ssrd','ssrdc','ws10','ws100','CS'], \n",
+    "@interact(var=list(ds.data_vars), \n",
     "          region=countries,\n",
     "          month=(1,12),\n",
     "          year=(1980,2018))\n",


### PR DESCRIPTION
Added configuration for binder notebook. Modified also the widget notebook to run on it without any further modifications:

https://mybinder.org/v2/gh/energy-modelling-toolkit/era-nuts-code/binder?filepath=notebooks%2FERA-NUTS-explore-with-widget.ipynb

Auto downloading two hourly variables netCDF files from Zenodo. 
In principle all could be downloaded but I didn't want to stress it: They recommend a data storage of a 'couple of hundreds MB'. Two variables demonstrate the concepts good enough though...

